### PR TITLE
Added macro tag for noetic compaibility

### DIFF
--- a/urdf/mimic_joint_gazebo_tutorial.urdf.xacro
+++ b/urdf/mimic_joint_gazebo_tutorial.urdf.xacro
@@ -58,7 +58,7 @@
     </gazebo>
   </xacro:macro>
 
-  <controller_plugin_gazebo />
+  <xacro:controller_plugin_gazebo />
 
   <!-- base_footprint + base_link -->
 


### PR DESCRIPTION
The example didn't work because in noetic versions all the XACRO MACROS have to have the xacro: tag prior to the name of the macro.